### PR TITLE
Fix: Add null checks to prevent workflow import crash

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -185,7 +185,16 @@ export function loadFromComfyWorkflow(
 }
 
 function patchConditioningNodes(nodes: Node[]) {
+  // Add null/undefined check for nodes array
+  if (!nodes || !Array.isArray(nodes)) {
+    console.warn('patchConditioningNodes: nodes is not a valid array:', nodes);
+    return;
+  }
+
   for (const node of nodes) {
+    // Add null check for individual node
+    if (!node) continue;
+    
     const conditioning = node.inputs?.filter(
       (input) => input.type === "CONDITIONING",
     );


### PR DESCRIPTION
Description:
## Bug Fix: Workflow Import Crash

### Problem
ComfyWeb crashes with `TypeError: nodes is not iterable` when importing workflows

### Solution
- Add null/undefined validation in `patchConditioningNodes` function
- Add individual node validation to prevent iteration errors
- Minimal fix that maintains backward compatibility

### Testing
- ✅ Tested with workflows that previously crashed
- ✅ No breaking changes to existing functionality
- ✅ Fixes critical workflow import issue